### PR TITLE
feat: 부서별 차트 및 기본 설정 개선

### DIFF
--- a/pages/api/fetchWMSArticles.js
+++ b/pages/api/fetchWMSArticles.js
@@ -8,9 +8,45 @@ export default async function handler(req,res){
     const db=client.db("yeongnam-visits");
     const col=db.collection("wms_data");
     const threeMonthsAgo=new Date(); threeMonthsAgo.setMonth(threeMonthsAgo.getMonth()-3);
-    const projection={ _id:1,nid:1,service_daytime:1,title:1,writers:1,level:1,embargo_type:1,reg_dt:1,reg_id:1,art_org_class:1,last_update:1,spellings:1 };
+  const projection={ _id:1,nid:1,service_daytime:1,title:1,writers:1,writer_buseo:1,level:1,embargo_type:1,reg_dt:1,reg_id:1,art_org_class:1,last_update:1,spellings:1 };
     const docs=await col.find({ service_daytime:{ $gte: threeMonthsAgo }, title:{ $exists:true } }).project(projection).sort({ service_daytime:-1 }).toArray();
-    const normalized=docs.map(a=>({ _id:a._id, newskey:a.nid||a._id, newsdate:a.service_daytime, newstitle:a.title, writers:a.writers, level:a.level||'5', embargo_type:a.embargo_type, reg_dt:a.reg_dt, reg_id:a.reg_id, art_org_class:a.art_org_class, last_update:a.last_update, spellings:a.spellings||"" }));
+
+    const prune = (obj)=>{
+      const out={};
+      for(const [k,v] of Object.entries(obj)){
+        if(v===undefined || v===null) continue;
+        if(typeof v==='string' && v.trim()==='') continue;
+        if(Array.isArray(v) && v.length===0) continue;
+        out[k]=v;
+      }
+      return out;
+    };
+
+    const normalized=docs.map(a=>{
+      // writer_buseo가 없을 경우 writers 배열에서 유추
+      let writerBuseo = a.writer_buseo;
+      if(!writerBuseo && Array.isArray(a.writers)){
+        const pickFields = (w)=> w?.buseo || w?.buseo_name || w?.dept || w?.department;
+        const buseoList = Array.from(new Set(a.writers.map(pickFields).filter(Boolean)));
+        if(buseoList.length) writerBuseo = buseoList.join(', ');
+      }
+      const obj = {
+        _id: a._id,
+        newskey: a.nid || a._id,
+        newsdate: a.service_daytime,
+        newstitle: a.title,
+        writers: a.writers,
+        writer_buseo: writerBuseo,
+        level: a.level || "5",
+        embargo_type: a.embargo_type,
+        reg_dt: a.reg_dt,
+        reg_id: a.reg_id,
+        art_org_class: a.art_org_class,
+        last_update: a.last_update,
+        spellings: a.spellings,
+      };
+      return prune(obj);
+    });
     if(normalized.length===0) return res.status(204).end();
     res.setHeader('Cache-Control','no-store');
     return res.status(200).json(normalized);

--- a/src/app/chart/chart.module.css
+++ b/src/app/chart/chart.module.css
@@ -90,14 +90,17 @@
   /* 1행: 순번(1) | 제목(3) 전체 2칸 */
   .webArticleTable tbody .td:nth-child(1){grid-column:1;grid-row:1;text-align:center;background:#f3f4f6;border-radius:6px;font-weight:700}
   .webArticleTable tbody .td:nth-child(3){grid-column:2/4;grid-row:1}
-  /* 2행: 출고일시(2) | 작성자(4) | 등급(5) */
+  /* 2행: 출고일시(2) | 작성자(5) | 부서(6) */
   .webArticleTable tbody .td:nth-child(2){grid-column:1;grid-row:2;border-top:1px solid #f3f4f6}
-  .webArticleTable tbody .td:nth-child(4){grid-column:2;grid-row:2}
-  .webArticleTable tbody .td:nth-child(5){grid-column:3;grid-row:2}
+  .webArticleTable tbody .td:nth-child(5){grid-column:2;grid-row:2}
+  .webArticleTable tbody .td:nth-child(6){grid-column:3;grid-row:2}
+  /* 3행: 오탈자(4) | 등급(7) */
+  .webArticleTable tbody .td:nth-child(4){grid-column:1;grid-row:3;border-top:1px solid #f3f4f6}
+  .webArticleTable tbody .td:nth-child(7){grid-column:2;grid-row:3}
   /* 불필요 필드(등록일시, 등록자, 분류)는 모바일에서 숨김 */
-  .webArticleTable tbody .td:nth-child(6),
-  .webArticleTable tbody .td:nth-child(7),
-  .webArticleTable tbody .td:nth-child(8){display:none}
+  .webArticleTable tbody .td:nth-child(8),
+  .webArticleTable tbody .td:nth-child(9),
+  .webArticleTable tbody .td:nth-child(10){display:none}
   /* 상단(순번, 제목) 라벨 제거로 깔끔하게 */
   .webArticleTable tbody .td:nth-child(1)::before,
   .webArticleTable tbody .td:nth-child(3)::before{display:none}

--- a/src/app/chart/components/StatsSection.jsx
+++ b/src/app/chart/components/StatsSection.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import styles from "../chart.module.css";
 import DailyArticleStats from "./charts/DailyArticleStats";
 import WebArticleList from "./tables/WebArticleList";
+import WebArticleDeptChart from "./WebArticleDeptChart";
 
 const StatsSection = () => {
   const [articlesData, setArticlesData] = useState([]);
@@ -33,6 +34,7 @@ const StatsSection = () => {
   return (
     <>
       <DailyArticleStats newsData={articlesData} />
+      <WebArticleDeptChart webArticleData={articlesData} />
       <WebArticleList webArticleData={articlesData} />
     </>
   );

--- a/src/app/chart/components/WebArticleDeptChart.jsx
+++ b/src/app/chart/components/WebArticleDeptChart.jsx
@@ -1,0 +1,149 @@
+"use client";
+import React, { useEffect, useMemo, useState } from "react";
+import styles from "../chart.module.css";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from "recharts";
+
+// 독립형 부서별 막대 차트: props.items가 없으면 API에서 직접 로드하고, 날짜 셀렉터로 오늘/어제 필터링
+export default function WebArticleDeptChart({ items }) {
+  const [selectedDatetime, setSelectedDatetime] = useState("today");
+  const [fetched, setFetched] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const dateGroups = useMemo(() => {
+    const t = new Date();
+    const y = new Date();
+    y.setDate(y.getDate() - 1);
+    return [
+      { value: "today", label: `오늘 (${t.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })})`, baseDate: t },
+      { value: "yesterday", label: `어제 (${y.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })})`, baseDate: y },
+    ];
+  }, []);
+
+  useEffect(() => {
+    let ignore = false;
+    if (items && items.length) return; // 부모에서 데이터를 주면 fetch 생략
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await fetch("/api/fetchWMSArticles");
+        if (res.status === 204) { if (!ignore) setFetched([]); return; }
+        if (!res.ok) throw new Error("API 실패");
+        const data = await res.json();
+        if (!ignore) setFetched(Array.isArray(data) ? data : (data?.items || []));
+      } catch (e) {
+        if (!ignore) setError(e?.message || "데이터를 불러오지 못했습니다.");
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => { ignore = true; };
+  }, [items]);
+
+  const baseList = useMemo(() => (items && items.length ? items : fetched), [items, fetched]);
+
+  const filtered = useMemo(() => {
+    const sel = dateGroups.find((g) => g.value === selectedDatetime);
+    let start, end;
+    if (sel?.baseDate) {
+      const d = sel.baseDate;
+      // UTC 경계 기준으로 하루 범위 계산 (API가 UTC 기반일 가능성 반영)
+      start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 0, 0, 0, 0));
+      end = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 23, 59, 59, 999));
+    }
+    const list = (baseList || []).filter((a) => {
+      if (!start || !end) return true;
+      const dt = a?.newsdate ? new Date(a.newsdate) : null;
+      return dt && dt.getTime() >= start.getTime() && dt.getTime() <= end.getTime();
+    });
+    return list.map((it) => {
+      // 부서명 정규화: writer_buseo가 "부서1, 부서2" 형태면 첫 번째만 사용, 공백 트림
+      const raw = typeof it?.writer_buseo === 'string' ? it.writer_buseo : (typeof it?.dept === 'string' ? it.dept : '');
+      const primary = raw ? raw.split(',')[0].trim() : '';
+      const dept = primary || '기타';
+      return { ...it, dept };
+    });
+  }, [baseList, selectedDatetime, dateGroups]);
+
+  const deptData = useMemo(() => {
+    const m = new Map(); // dept -> { total, self, nonSelf }
+    for (const it of filtered || []) {
+      const dept = it?.dept || "기타";
+      const lvl = it?.level;
+      const isSelf = String(lvl) === "1" || Number(lvl) === 1; // 자체
+      if (!m.has(dept)) m.set(dept, { total: 0, self: 0, nonSelf: 0 });
+      const v = m.get(dept);
+      v.total += 1;
+      if (isSelf) v.self += 1; else v.nonSelf += 1;
+    }
+    const rows = Array.from(m, ([name, v]) => {
+      const ratio = v.total ? Math.round((v.self / v.total) * 100) : 0; // 자체 비율 %
+      return { name, count: v.total, self: v.self, nonSelf: v.nonSelf, ratio };
+    }).sort((a, b) => b.count - a.count);
+    return rows;
+  }, [filtered]);
+
+  const getBarColor = (ratio) => (ratio >= 35 ? '#34d399' : ratio >= 25 ? '#fcd34d' : '#f87171');
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <div>
+          <div className={styles.cardTitle}>부서별 웹출고 현황</div>
+          <div className={styles.cardDesc}>현재 선택된 날짜 기준으로 집계합니다.</div>
+        </div>
+        <div className={styles.selectRow}>
+          <select className={styles.select} value={selectedDatetime} onChange={(e) => setSelectedDatetime(e.target.value)}>
+            {dateGroups.map((g) => (
+              <option key={g.value} value={g.value}>
+                {g.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className={styles.cardContent}>
+        {loading && (
+          <div style={{ color: '#6b7280', fontSize: 12, marginBottom: 8 }}>데이터를 불러오는 중...</div>
+        )}
+        {error && (
+          <div style={{ color: '#b91c1c', fontSize: 12, marginBottom: 8 }}>로딩 실패: {error}</div>
+        )}
+        <div style={{ width: '100%', height: 250 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={deptData} margin={{ left: 0, right: 20 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={4} interval="preserveStartEnd" tick={{ fontSize: 10 }} />
+              <YAxis tickLine={false} axisLine={false} tickMargin={4} tickCount={4} tick={{ fontSize: 10 }} />
+              <Tooltip
+                cursor={{ fill: 'rgba(0,0,0,0.04)' }}
+                content={({ active, payload, label }) => {
+                  if (!active || !payload || !payload.length) return null;
+                  const d = payload[0].payload;
+                  return (
+                    <div style={{ background:'#fff', border:'1px solid #e5e7eb', borderRadius:6, padding:'8px 10px', boxShadow:'0 2px 6px rgba(0,0,0,.08)', fontSize:12 }}>
+                      <div style={{ fontWeight:700, marginBottom:4 }}>{label}</div>
+                      <div>전체: {d.count}건</div>
+                      <div>자체: {d.self}건</div>
+                      <div>비자체: {d.nonSelf}건</div>
+                      <div style={{ marginTop:4, color:'#6b7280' }}>자체비율: {d.ratio}%</div>
+                    </div>
+                  );
+                }}
+              />
+              <Bar dataKey="count" radius={[4, 4, 0, 0]} fillOpacity={0.9}>
+                {deptData.map((d) => (
+                  <Cell key={d.name} fill={getBarColor(d.ratio)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        {(!loading && !error && deptData.length === 0) && (
+          <div style={{ marginTop: 8, fontSize: 12, color: '#6b7280' }}>표시할 데이터가 없습니다.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/chart/components/charts/LevelChart.jsx
+++ b/src/app/chart/components/charts/LevelChart.jsx
@@ -29,7 +29,7 @@ function transformMonthly(news){
 const fmtKorean=(v)=>v.toLocaleString();
 
 const LevelChart=({newsData})=>{
-  const [period,setPeriod]=useState('weekly');
+  const [period,setPeriod]=useState('monthly');
   const [selectedMonth,setSelectedMonth]=useState('all');
   const weekly=useMemo(()=>transformWeekly(newsData),[newsData]);
   const monthly=useMemo(()=>transformMonthly(newsData),[newsData]);

--- a/src/app/chart/components/charts/ViewChart.jsx
+++ b/src/app/chart/components/charts/ViewChart.jsx
@@ -4,20 +4,57 @@ import styles from "../../chart.module.css";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis, ResponsiveContainer, Tooltip } from "recharts";
 import { getWeekKey, getMonthKey } from "../../lib/dateUtils";
 
-const colors={ total:'#0ea5e9', digital:'#f59e0b' };
+const colors={ total:'#0ea5e9', dept:'#f59e0b' };
 const FILTER_MONTHS=3;
 const fmtKorean=(v)=>{ if(v>=1e8) return `${Math.round(v/1e7)/10}억`; if(v>=1e4) return `${Math.round(v/1e3)/10}만`; return v.toLocaleString(); };
 const fmtDate=(s)=>{ const d=new Date(s); return `${String(d.getMonth()+1).padStart(2,'0')}.${String(d.getDate()).padStart(2,'0')}`; };
 
-const toWeekly=(arts)=>{ const m=new Map(); for(const a of arts||[]){ if(a.newsclass_names?.includes('운세')) continue; const wk=getWeekKey(a.newsdate).split('T')[0]; if(!m.has(wk)) m.set(wk,{date:wk,total:0,digital:0}); const it=m.get(wk); const ref=Number(a.ref)||0; it.total+=ref; if(a.code_name==='디지털뉴스부') it.digital+=ref; } return Array.from(m.values()).sort((a,b)=>new Date(a.date)-new Date(b.date)); };
-const toMonthly=(arts)=>{ const m=new Map(); for(const a of arts||[]){ if(a.newsclass_names?.includes('운세')) continue; const mk=getMonthKey(a.newsdate).split('T')[0]; if(!m.has(mk)) m.set(mk,{date:mk,total:0,digital:0}); const it=m.get(mk); const ref=Number(a.ref)||0; it.total+=ref; if(a.code_name==='디지털뉴스부') it.digital+=ref; } return Array.from(m.values()).sort((a,b)=>new Date(a.date)-new Date(b.date)); };
+const toWeekly=(arts, selectedDept)=>{ 
+  const m=new Map(); 
+  for(const a of arts||[]){ 
+    if(a.newsclass_names?.includes('운세')) continue; 
+    const wk=getWeekKey(a.newsdate).split('T')[0]; 
+    if(!m.has(wk)) m.set(wk,{date:wk,total:0,dept:0}); 
+    const it=m.get(wk); 
+    const ref=Number(a.ref)||0; 
+    it.total+=ref; 
+    // DepartmentViewTable과 동일하게 code_name을 직접 비교
+    if(selectedDept && a.code_name===selectedDept) it.dept+=ref; 
+  } 
+  return Array.from(m.values()).sort((a,b)=>new Date(a.date)-new Date(b.date)); 
+};
+const toMonthly=(arts, selectedDept)=>{ 
+  const m=new Map(); 
+  for(const a of arts||[]){ 
+    if(a.newsclass_names?.includes('운세')) continue; 
+    const mk=getMonthKey(a.newsdate).split('T')[0]; 
+    if(!m.has(mk)) m.set(mk,{date:mk,total:0,dept:0}); 
+    const it=m.get(mk); 
+    const ref=Number(a.ref)||0; 
+    it.total+=ref; 
+    // DepartmentViewTable과 동일하게 code_name을 직접 비교
+    if(selectedDept && a.code_name===selectedDept) it.dept+=ref; 
+  } 
+  return Array.from(m.values()).sort((a,b)=>new Date(a.date)-new Date(b.date)); 
+};
 
 const ViewChart=({newsData})=>{
-  const [period,setPeriod]=useState('weekly');
+  const [period,setPeriod]=useState('monthly');
   const [selectedMonth,setSelectedMonth]=useState('all');
+  const [selectedDept,setSelectedDept]=useState(''); // 초기값을 빈 문자열로 설정
 
-  const weekly=useMemo(()=>toWeekly(newsData),[newsData]);
-  const monthly=useMemo(()=>toMonthly(newsData),[newsData]);
+  // 실제 데이터에서 사용되는 부서명 추출
+  const availableDepts = useMemo(() => {
+    if(!newsData?.length) return [];
+    const deptSet = new Set();
+    newsData.forEach(a => {
+      if(a.code_name) deptSet.add(a.code_name);
+    });
+    return Array.from(deptSet).sort();
+  }, [newsData]);
+
+  const weekly=useMemo(()=>toWeekly(newsData, selectedDept),[newsData, selectedDept]);
+  const monthly=useMemo(()=>toMonthly(newsData, selectedDept),[newsData, selectedDept]);
 
   const months=useMemo(()=>{ if(period!=='weekly'||!weekly.length) return []; const set=new Set(); weekly.forEach(i=>{const d=new Date(i.date); const key=`${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`; set.add(key);}); return Array.from(set).sort().reverse().map(v=>({value:v,label:`${v.split('-')[0]}년 ${parseInt(v.split('-')[1])}월`})); },[weekly,period]);
 
@@ -32,10 +69,21 @@ const ViewChart=({newsData})=>{
     <div className={styles.card}>
       <div className={styles.cardHeader}>
         <div>
-          <div className={styles.cardTitle}>디지털팀 조회수 현황 ({period==='weekly'? '주별':'월별'})</div>
-          <div className={styles.cardDesc}>{period==='weekly'? '매주 일요일 ~ 토요일 기준':'월별 기준'}</div>
+          <div className={styles.cardTitle}>
+            {selectedDept ? `전체 대비 ${selectedDept} 조회수 현황` : '부서별 조회수 현황'} ({period==='weekly'? '주별':'월별'})
+          </div>
+          <div className={styles.cardDesc}>
+            {period==='weekly'? '매주 일요일 ~ 토요일 기준':'월별 기준'}
+            {selectedDept && ` · 선택 부서: ${selectedDept}`}
+          </div>
         </div>
         <div className={styles.selectRow}>
+          <select className={styles.select} value={selectedDept} onChange={e=>setSelectedDept(e.target.value)}>
+            <option value="">부서선택</option>
+            {availableDepts.map((dept)=>(
+              <option key={dept} value={dept}>{dept}</option>
+            ))}
+          </select>
           <select className={styles.select} value={period} onChange={e=>setPeriod(e.target.value)}>
             <option value="weekly">주별</option>
             <option value="monthly">월별</option>
@@ -57,9 +105,9 @@ const ViewChart=({newsData})=>{
                 <stop offset="5%" stopColor={colors.total} stopOpacity={0.8} />
                 <stop offset="95%" stopColor={colors.total} stopOpacity={0.1} />
               </linearGradient>
-              <linearGradient id="filldigital" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={colors.digital} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={colors.digital} stopOpacity={0.1} />
+              <linearGradient id="filldept" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={colors.dept} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={colors.dept} stopOpacity={0.1} />
               </linearGradient>
             </defs>
             <CartesianGrid vertical={false} />
@@ -70,8 +118,11 @@ const ViewChart=({newsData})=>{
             <Tooltip 
               cursor={false}
               formatter={(value, name) => {
-                const label = name === 'digital' ? '디지털뉴스부' : '전체부서';
-                return [fmtKorean(Number(value)), label];
+                if(name === 'dept') {
+                  const label = selectedDept || '선택된 부서';
+                  return [fmtKorean(Number(value)), label];
+                }
+                return [fmtKorean(Number(value)), '전체부서'];
               }}
               labelFormatter={(v) => {
                 if(period==='weekly') return fmtDate(v);
@@ -79,7 +130,7 @@ const ViewChart=({newsData})=>{
                 return `${d.getFullYear()}년 ${d.getMonth()+1}월`;
               }}
             />
-            <Area dataKey="digital" type="linear" fill="url(#filldigital)" fillOpacity={0.4} stroke={colors.digital} stackId="a" />
+            <Area dataKey="dept" type="linear" fill="url(#filldept)" fillOpacity={0.4} stroke={colors.dept} stackId="a" />
             <Area dataKey="total" type="linear" fill="url(#filltotal)" fillOpacity={0.4} stroke={colors.total} stackId="a" />
           </AreaChart>
           </ResponsiveContainer>

--- a/src/app/chart/components/tables/WebArticleList.jsx
+++ b/src/app/chart/components/tables/WebArticleList.jsx
@@ -7,7 +7,7 @@ import { idToName } from "../../data/userMapping";
 import { getCategoryName } from "../../data/categoryMapping";
 import HighlightedTextModal from "../HighlightedTextModal";
 
-const columns = ["순번", "출고일시", "제목", "교열", "작성자", "등급", "등록일시", "등록자ID", "분류"];
+const columns = ["순번", "출고일시", "제목", "교열", "작성자", "부서", "등급", "등록일시", "등록자ID", "분류"];
 
 export default function WebArticleList({ webArticleData }) {
   const [selectedDatetime, setSelectedDatetime] = useState("today");
@@ -56,7 +56,8 @@ const getSpellings = async (nid) => {
   const webArticles = useMemo(() => {
     const sel = dateGroups.find((g) => g.value === selectedDatetime);
     const list = (webArticleData || []).filter((a) => (sel ? a.newsdate && String(a.newsdate).startsWith(sel.dateStr) : true));
-    return list;
+    // 역매핑 없이 writer_buseo가 있으면 사용, 없으면 '기타'
+    return list.map((it) => ({ ...it, dept: it.writer_buseo || "기타" }));
   }, [webArticleData, selectedDatetime, dateGroups]);
 
   const sorted = useMemo(() => sortData(webArticles), [webArticles, sortData]);
@@ -66,13 +67,17 @@ const getSpellings = async (nid) => {
     return sorted.slice(start, start + itemsPerPage);
   }, [sorted, currentPage]);
 
+  // 차트는 분리된 컴포넌트(WebArticleDeptChart)로 렌더링합니다.
+
   // 날짜 필터 변경 시 1페이지로 리셋
   React.useEffect(() => {
     setCurrentPage(1);
   }, [selectedDatetime]);
 
   return (
-    <div className={styles.card}>
+    <>
+      {/* 하단 카드: 웹출고 기사 목록 */}
+      <div className={styles.card}>
       <div className={styles.cardHeader}>
         <div>
           <div className={styles.cardTitle}>웹출고 기사 목록</div>
@@ -92,9 +97,9 @@ const getSpellings = async (nid) => {
         <table className={styles.table + " " + styles.webArticleTable}>
           <thead>
             <tr className={styles.tr}>
-              {columns.map((c, idx) => (
+        {columns.map((c, idx) => (
                 <th key={idx} className={styles.th}>
-                  <button className={styles.tabBtn} onClick={() => handleSort(["index", "newsdate", "newstitle", "spellings", "writers", "level", "reg_dt", "reg_id", "art_org_class"][idx])}>
+          <button className={styles.tabBtn} onClick={() => handleSort(["index", "newsdate", "newstitle", "spellings", "writers", "dept", "level", "reg_dt", "reg_id", "art_org_class"][idx])}>
                     {c}
                   </button>
                 </th>
@@ -129,6 +134,9 @@ const getSpellings = async (nid) => {
 
                 <td className={styles.td} data-label="작성자" title={item.writers}>
                   {item.writers ? truncateText(item.writers, 10) : "-"}
+                </td>
+                <td className={styles.td} data-label="부서" title={item.dept}>
+                  {item.dept || "-"}
                 </td>
                 <td className={styles.td} data-label="등급">
                   <span className={getLevelClass(item.level)}>{formatLevel(item.level)}</span>
@@ -250,5 +258,6 @@ const getSpellings = async (nid) => {
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/src/app/chart/data/departmentMapping.js
+++ b/src/app/chart/data/departmentMapping.js
@@ -1,0 +1,133 @@
+// 부서별 기자 목록 및 부서 코드 매핑 (categoryMapping.js에서 분리)
+
+// 부서별 기자 목록
+export const departmentMembers = {
+  논설실: [
+    { name: "박재일", id: "park11", webId: "wa910150" },
+    { name: "윤철희", id: "fehy", webId: "wa910183" },
+    { name: "김수영", id: "sykim", webId: "wa910198" },
+    { name: "전영", id: "younger", webId: "wa940382" },
+    { name: "김진욱", id: "jwook", webId: "wa910107" },
+  ],
+  사진팀: [
+    { name: "이지용", id: "sajahu", webId: "wa900837" },
+    { name: "이현덕", id: "lhd", webId: "waa13133" },
+    { name: "이윤호", id: "yoonhohi", webId: "waa14847" },
+  ],
+  정치: [
+    { name: "진식", id: "jins", webId: "waa12700" },
+    { name: "권혁준", id: "hyeokjun", webId: "waa13935" },
+    { name: "정재훈", id: "jjhoon", webId: "waa13638" },
+    { name: "서정혁", id: "seo1900", webId: "waa13925" },
+    { name: "구경모(세종)", id: "chosim34", webId: "waa13915" },
+    { name: "장태훈", id: "hun2", webId: "waa15015" },
+  ],
+  경제: [
+    { name: "임성수", id: "s018", webId: "waa11825" },
+    { name: "홍석천", id: "hongsc", webId: "waa14343" },
+    { name: "이승엽", id: "sylee", webId: "waa14853" },
+    { name: "이동현(경제)", id: "shineast", webId: "waa14703" },
+    { name: "윤정혜", id: "hye", webId: "waa14985" },
+    { name: "최미애", id: "miaechoi21", webId: "waa13850" },
+    { name: "이남영", id: "lny0104", webId: "waa14589" },
+  ],
+  사회: [
+    { name: "최수경", id: "justone", webId: "waa11863" },
+    { name: "노진실", id: "know", webId: "waa13265" },
+    { name: "최시웅", id: "jet123", webId: "waa14511" },
+    { name: "박영민", id: "ympark", webId: "waa14895" },
+    { name: "이동현(사회)", id: "leedh", webId: "waa14943" },
+    { name: "구경모(대구)", id: "kk0906", webId: "waa15009" },
+    { name: "조윤화", id: "truehwa", webId: "waa15021" },
+    { name: "강승규", id: "kang", webId: "waa12999" },
+    { name: "김종윤", id: "bell08", webId: "waa14997" },
+  ],
+  경북: [
+    { name: "임호", id: "tiger35", webId: "waa11859" },
+    { name: "이창호", id: "leech", webId: "waa13190" },
+    { name: "박종진", id: "pjj", webId: "waa12885" },
+    { name: "오주석", id: "farbrother", webId: "waa14517" },
+    { name: "피재윤", id: "ssanaei", webId: "waa14487" },
+    { name: "마창훈", id: "topgun", webId: "waa12588" },
+    { name: "장석원", id: "history", webId: "waa13312" },
+    { name: "황준오", id: "joono", webId: "waa13326" },
+    { name: "손병현", id: "why", webId: "waa14571" },
+    { name: "배운철", id: "baeuc", webId: "waa13246" },
+    { name: "정운홍", id: "jwh", webId: "waa15003" },
+    { name: "마창성", id: "mcs12", webId: "wa970920" },
+    { name: "김기태", id: "ktk", webId: "waa14211" },
+    { name: "전준혁", id: "jjh", webId: "waa14835" },
+    { name: "박성우", id: "parksw", webId: "waa13015" },
+    { name: "유시룡", id: "ysy" },
+    { name: "원형래", id: "Hrw7349", webId: "waa14403" },
+    { name: "정용태", id: "jyt", webId: "waa12475" },
+    { name: "남두백", id: "dbnam", webId: "waa13307" },
+    { name: "장성재", id: "blowpaper", webId: "waa14991" },
+    { name: "박진관", id: "pajika", webId: "wa910230" },
+    { name: "백종현", id: "baekjh", webId: "wa960235" },
+    { name: "박용기", id: "ygpark", webId: "waa14865" },
+    { name: "마준영", id: "mj3407", webId: "waa12376" },
+    { name: "석현철", id: "shc", webId: "waa13775" },
+    { name: "이하수", id: "songam", webId: "wa881073" },
+    { name: "박현주", id: "hjpark", webId: "waa13825" },
+    { name: "강남진", id: "75kangnj", webId: "waa15033" },
+  ],
+  문화체육: [
+    { name: "백승운", id: "swback", webId: "waa11434" },
+    { name: "박주희", id: "jh", webId: "waa12517" },
+    { name: "임훈", id: "hoony", webId: "waa13482" },
+    { name: "조현희", id: "hyunhee", webId: "waa14739" },
+    { name: "정수민", id: "jsmean", webId: "waa14925" },
+    { name: "이효설", id: "hobak", webId: "waa12277" },
+    { name: "정지윤", id: "yooni", webId: "waa14523" },
+    { name: "김은경", id: "enigma" },
+  ],
+  디지털: [
+    { name: "이지영", id: "4to11", webId: "waa14859" },
+    { name: "서민지", id: "mjs858", webId: "waa14457" },
+    { name: "서혜지", id: "hyeji", webId: "waa14691" },
+    { name: "박지현", id: "lozpjh", webId: "waa14907" },
+    { name: "서영현", id: "rhdqnsk1216" },
+  ],
+  스토리텔링: [
+    { name: "이은경", id: "lek", webId: "waa10407" },
+    { name: "박관영", id: "zone5", webId: "wa900172" },
+    { name: "박준상", id: "junsang", webId: "waa14331" },
+  ],
+  기타: [
+    { name: "변종현", id: "byeonjh", webId: "waa13208" },
+    { name: "천부영", id: "exprich", webId: "waa12296" },
+    { name: "김기오", id: "mvalley", webId: "wa900856" },
+    { name: "이애란", id: "aerani", webId: "wa950360" },
+    { name: "안희정", id: "anhj", webId: "waa11608" },
+    { name: "임종규", id: "gumbo89", webId: "waa14000" },
+    { name: "공미혜", id: "iskra96", webId: "waa12159" },
+    { name: "나은정", id: "mercury", webId: "waa13171" },
+    { name: "조영선", id: "sun0930", webId: "waa14499" },
+    { name: "구지연", id: "neim35", webId: "waa14433" },
+    { name: "전주현", id: "waa13581", webId: "waa13581" },
+    { name: "배재석", id: "baejs", webId: "wa880787" },
+    { name: "조은주", id: "funej", webId: "waa13945" },
+  ],
+};
+
+// 부서명 리스트(UI 셀렉트 옵션용)
+export const departmentNames = Object.keys(departmentMembers);
+
+// 기사 데이터의 code_name과 UI 부서명을 매핑
+// 데이터의 code_name이 예: '디지털뉴스부','정치부','경제부','사회부','경북부','문화체육부','사진부','스토리텔링팀','논설실' 등일 때를 커버
+export const departmentCodeNameMap = {
+  '디지털': '디지털뉴스부',
+  '정치': '정치부',
+  '경제': '경제부',
+  '사회': '사회부',
+  '경북': '경북부',
+  '문화체육': '문화체육부',
+  '사진팀': '사진부',
+  '스토리텔링': '스토리텔링팀',
+  '논설실': '논설실',
+  '기타': '기타',
+};
+
+// UI 부서명을 기사 code_name으로 변환(없으면 원문 반환)
+export const getDeptCodeName = (dept) => departmentCodeNameMap[dept] || dept;

--- a/src/app/chart/lib/tableUtils.js
+++ b/src/app/chart/lib/tableUtils.js
@@ -3,4 +3,4 @@ import styles from "../chart.module.css";
 export function truncateText(text,max){if(!text) return "-";return text.length>max?text.slice(0,max)+"…":text;}
 export function formatLevel(level){const l=String(level||"5");if(l==="1") return "자체";return `비자체`;}
 export function getLevelClass(level){return String(level)==="1"?`${styles.badge} ${styles.levelSelf}`:`${styles.badge} ${styles.levelNonSelf}`;}
-export function getSelfRatioClass(r){if(r>=35) return `${styles.badge} ${styles.badgeGreen}`; if(r>=20) return `${styles.badge} ${styles.badgeYellow}`; return `${styles.badge} ${styles.badgeGray}`;}
+export function getSelfRatioClass(r){if(r>=35) return `${styles.badge} ${styles.badgeGreen}`; if(r>=25) return `${styles.badge} ${styles.badgeYellow}`; return `${styles.badge} ${styles.badgeGray}`;}


### PR DESCRIPTION
## 주요 변경사항

### 차트 기본값 변경
- ViewChart와 LevelChart의 기본 기간을 'weekly'에서 'monthly'로 변경
- 사용자 접속 시 월별 데이터를 기본으로 표시하도록 개선

### 부서 데이터 처리 개선
- API에 writer_buseo 필드 추가 및 데이터 정규화 로직 구현
- 빈 필드 제거(prune) 함수로 응답 데이터 최적화
- 부서 매핑을 departmentMapping.js로 분리

### ViewChart 부서 선택 기능 강화
- 실제 데이터에서 부서명을 동적으로 추출
- 부서 선택 시 해당 부서와 전체 조회수 비교 차트 제공
- DepartmentViewTable과 동일한 code_name 직접 비교 방식 적용

### WebArticleList 개선
- 부서 컬럼 추가 (writer_buseo 필드 활용)
- 독립형 WebArticleDeptChart 컴포넌트 분리
- StatsSection에 부서별 막대 차트 추가

### 운세 기사 필터링 통일
- PersonalViewTable에 '운세 제외' 옵션 추가
- 모든 차트와 테이블에서 일관된 운세 필터링 적용

### UI/UX 개선
- 모바일 레이아웃에서 부서 컬럼 표시 최적화
- 자체 비율 기준값을 20%에서 25%로 조정
- PersonalViewTable에 요약 통계 추가